### PR TITLE
Add basic shipment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # GI
+
+This project contains a minimal shipping API implemented in Python.
+
+## Setup
+
+The source code lives in `src/` and does not rely on external
+packages. Start the API server with:
+
+```bash
+python src/app.py
+```
+
+The server exposes the following endpoints:
+
+- `POST /shipments` – create a shipment. Provide JSON with
+  `{"order_id": "<id>", "carrier": "<name>"}`.
+- `GET /shipments/<shipment_id>` – retrieve shipment details.
+
+## Testing
+
+Run the tests using `pytest`:
+
+```bash
+pytest
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "gi"
+version = "0.1.0"
+description = "Minimal shipping API"
+requires-python = ">=3.8"

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,49 @@
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import uuid
+
+shipments = {}
+
+class ShipmentHandler(BaseHTTPRequestHandler):
+    def _set_headers(self, status=200):
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+
+    def do_POST(self):
+        if self.path == '/shipments':
+            length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(length)
+            data = json.loads(body or b'{}')
+            shipment_id = str(uuid.uuid4())
+            shipment = {
+                'id': shipment_id,
+                'order_id': data.get('order_id'),
+                'carrier': data.get('carrier'),
+                'status': 'created'
+            }
+            shipments[shipment_id] = shipment
+            self._set_headers(201)
+            self.wfile.write(json.dumps(shipment).encode())
+        else:
+            self.send_error(404)
+
+    def do_GET(self):
+        if self.path.startswith('/shipments/'):
+            shipment_id = self.path.split('/')[-1]
+            shipment = shipments.get(shipment_id)
+            if shipment:
+                self._set_headers(200)
+                self.wfile.write(json.dumps(shipment).encode())
+            else:
+                self.send_error(404, 'Shipment not found')
+        else:
+            self.send_error(404)
+
+def run(host='127.0.0.1', port=8000):
+    httpd = HTTPServer((host, port), ShipmentHandler)
+    print(f"Serving on {host}:{port}")
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+@dataclass
+class Order:
+    id: str
+    description: str
+
+@dataclass
+class Carrier:
+    name: str
+
+@dataclass
+class Shipment:
+    id: str
+    order_id: str
+    carrier: str
+    status: str = "created"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import json
+import threading
+import time
+import urllib.request
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src import app
+
+
+def start_server():
+    server = app.HTTPServer(('127.0.0.1', 8001), app.ShipmentHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server
+
+
+def test_create_and_get_shipment():
+    server = start_server()
+    time.sleep(0.1)
+
+    data = json.dumps({'order_id': '1', 'carrier': 'UPS'}).encode()
+    req = urllib.request.Request(
+        'http://127.0.0.1:8001/shipments',
+        data=data,
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    with urllib.request.urlopen(req) as resp:
+        assert resp.status == 201
+        body = json.load(resp)
+        shipment_id = body['id']
+
+    with urllib.request.urlopen(f'http://127.0.0.1:8001/shipments/{shipment_id}') as resp:
+        assert resp.status == 200
+        body = json.load(resp)
+        assert body['order_id'] == '1'
+        assert body['carrier'] == 'UPS'
+
+    server.shutdown()
+    server.server_close()


### PR DESCRIPTION
## Summary
- initialize `src/` with a basic shipping API
- allow creating and retrieving shipments via HTTP
- add simple dataclass models
- provide pytest covering the API
- update README with usage instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6863991943e483238ee332e9f7b3da00